### PR TITLE
Clearer error message on invalid argument.

### DIFF
--- a/lib/wilson_score.rb
+++ b/lib/wilson_score.rb
@@ -4,6 +4,7 @@ module WilsonScore
 
   # http://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval
   def self.interval(k, n, *args)
+    raise ArgumentError.new ('second parameter cannot be 0') if n.zero?
     args = args.dup
     options = args[-1].is_a?(Hash) ? args.pop : {}
     confidence = args[0] || options[:confidence] || 0.95

--- a/test/wilson_score_test.rb
+++ b/test/wilson_score_test.rb
@@ -70,4 +70,8 @@ class TestWilsonScore < Minitest::Test
     assert_in_delta 1.8262, WilsonScore.rating_lower_bound(5, 1, 1..5, correction: false)
   end
 
+  def test_invalid_argument
+    assert_raises(ArgumentError) { WilsonScore.interval(0, 0) }
+  end
+
 end


### PR DESCRIPTION
As discussed in #3 

On second thought, returning `0` for `(0, 0)` would make it impossible to tell it from valid cases like `(0, 1)`, and it just sweeps the root problem under the rug.

Instead, `ArgumentError` is semantically appropriate, and intuitive even for the people who don't understand the internal formula. So it's just the error message that needed clarity.